### PR TITLE
Add Files storage system with IndexedDB persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vueuse/core": "^10.9.0",
         "html-to-image": "^1.11.13",
+        "idb": "^8.0.3",
         "lodash": "^4.17.21",
         "pinia": "^2.1.7",
         "sass": "^1.77.2",
@@ -3703,6 +3704,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@vueuse/core": "^10.9.0",
     "html-to-image": "^1.11.13",
+    "idb": "^8.0.3",
     "lodash": "^4.17.21",
     "pinia": "^2.1.7",
     "sass": "^1.77.2",

--- a/src/components/EditBar/EditBarCardStats.vue
+++ b/src/components/EditBar/EditBarCardStats.vue
@@ -34,6 +34,7 @@ const handleRange = ({ target: { name, value } }) => {
          name="name"
          placeholder="Name"
          autocomplete="off"
+         autocapitalize="words"
          :value="card.name"
          @input="handleValue"
       />

--- a/src/components/Files/FilesModal.vue
+++ b/src/components/Files/FilesModal.vue
@@ -67,6 +67,11 @@ const handleSaveFile = async () => {
    $toast.success('File saved!');
 };
 
+const handleNew = () => {
+   cardStore.reset();
+   $toast.success('New card created');
+};
+
 const handleLoadFile = (file) => {
    cardStore.setFromParams(new URLSearchParams(file.params));
    $toast.success(`Loaded "${file.name}"`);
@@ -127,6 +132,10 @@ const isEmpty = computed(() =>
                class="action-btn"
                @click="toggleFileInput"
             >+ Save File</button>
+            <button
+               class="action-btn new-btn"
+               @click="handleNew"
+            >+ New</button>
          </div>
 
          <div v-if="showFolderInput" class="inline-input-row">
@@ -254,6 +263,10 @@ const isEmpty = computed(() =>
 .files-actions {
    display: flex;
    gap: 0.5rem;
+
+   .new-btn {
+      margin-left: auto;
+   }
 
    .action-btn {
       background: rgba(255, 255, 255, 0.07);

--- a/src/components/Files/FilesModal.vue
+++ b/src/components/Files/FilesModal.vue
@@ -1,0 +1,408 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { VueFinalModal } from 'vue-final-modal';
+import { useToast } from 'vue-toast-notification';
+import { useCardStore } from '@/stores/card.store';
+import { useFilesStore } from '@/stores/files.store';
+import { buildCardParams } from '@/utils/serializeState';
+import { BaseHr } from '../common';
+
+defineEmits(['close']);
+
+const cardStore = useCardStore();
+const filesStore = useFilesStore();
+const $toast = useToast();
+
+onMounted(() => filesStore.load());
+
+const currentFolderId = ref(null);
+const showFolderInput = ref(false);
+const newFolderName = ref('');
+const showFileInput = ref(false);
+const newFileName = ref('');
+
+const isAtRoot = computed(() => currentFolderId.value === null);
+const currentFolder = computed(() => filesStore.folders.find((f) => f.id === currentFolderId.value) ?? null);
+const visibleFiles = computed(() => filesStore.files.filter((f) => f.folderId === currentFolderId.value));
+const rootFiles = computed(() => filesStore.files.filter((f) => f.folderId === null));
+
+const enterFolder = (id) => {
+   currentFolderId.value = id;
+   showFolderInput.value = false;
+   showFileInput.value = false;
+};
+
+const goToRoot = () => {
+   currentFolderId.value = null;
+   showFolderInput.value = false;
+   showFileInput.value = false;
+};
+
+const toggleFolderInput = () => {
+   showFolderInput.value = !showFolderInput.value;
+   showFileInput.value = false;
+   newFolderName.value = '';
+};
+
+const toggleFileInput = () => {
+   showFileInput.value = !showFileInput.value;
+   showFolderInput.value = false;
+   newFileName.value = '';
+};
+
+const handleCreateFolder = async () => {
+   const name = newFolderName.value.trim();
+   if (!name) return;
+   await filesStore.createFolder(name);
+   newFolderName.value = '';
+   showFolderInput.value = false;
+};
+
+const handleSaveFile = async () => {
+   const name = newFileName.value.trim();
+   if (!name) return;
+   await filesStore.saveFile(name, buildCardParams(cardStore), currentFolderId.value);
+   newFileName.value = '';
+   showFileInput.value = false;
+   $toast.success('File saved!');
+};
+
+const handleLoadFile = (file) => {
+   cardStore.setFromParams(new URLSearchParams(file.params));
+   $toast.success(`Loaded "${file.name}"`);
+};
+
+const handleDeleteFolder = async (folder) => {
+   if (!confirm(`Delete folder "${folder.name}" and all its files?`)) return;
+   await filesStore.deleteFolder(folder.id);
+};
+
+const handleDeleteFile = async (file) => {
+   if (!confirm(`Delete "${file.name}"?`)) return;
+   await filesStore.deleteFile(file.id);
+};
+
+const formatDate = (ts) =>
+   new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+
+const isEmpty = computed(() =>
+   isAtRoot.value
+      ? filesStore.folders.length === 0 && rootFiles.value.length === 0
+      : visibleFiles.value.length === 0,
+);
+</script>
+
+<template>
+   <VueFinalModal
+      class="modal"
+      content-class="modal-content files-modal-content"
+      overlay-transition="vfm-fade"
+      content-transition="vfm-fade"
+   >
+      <div class="files-modal">
+         <div class="files-header">
+            <h1>Files</h1>
+            <BaseHr />
+         </div>
+
+         <nav class="breadcrumb">
+            <span
+               class="breadcrumb-item"
+               :class="{ active: isAtRoot }"
+               @click="goToRoot"
+            >All Files</span>
+            <template v-if="!isAtRoot">
+               <span class="breadcrumb-sep">›</span>
+               <span class="breadcrumb-item active">{{ currentFolder?.name }}</span>
+            </template>
+         </nav>
+
+         <div class="files-actions">
+            <button
+               v-if="isAtRoot"
+               class="action-btn"
+               @click="toggleFolderInput"
+            >+ Create Folder</button>
+            <button
+               class="action-btn"
+               @click="toggleFileInput"
+            >+ Save File</button>
+         </div>
+
+         <div v-if="showFolderInput" class="inline-input-row">
+            <input
+               v-model="newFolderName"
+               placeholder="Folder name..."
+               autofocus
+               @keyup.enter="handleCreateFolder"
+               @keyup.esc="showFolderInput = false"
+            />
+            <button @click="handleCreateFolder">Save</button>
+            <button @click="showFolderInput = false">Cancel</button>
+         </div>
+
+         <div v-if="showFileInput" class="inline-input-row">
+            <input
+               v-model="newFileName"
+               placeholder="File name..."
+               autofocus
+               @keyup.enter="handleSaveFile"
+               @keyup.esc="showFileInput = false"
+            />
+            <button @click="handleSaveFile">Save</button>
+            <button @click="showFileInput = false">Cancel</button>
+         </div>
+
+         <div class="files-list">
+            <p v-if="isEmpty" class="empty-state">
+               <template v-if="isAtRoot">No saved files yet. Hit "+ Save File" to save your current card.</template>
+               <template v-else>This folder is empty.</template>
+            </p>
+
+            <template v-if="isAtRoot">
+               <div
+                  v-for="folder in filesStore.folders"
+                  :key="folder.id"
+                  class="list-row folder-row"
+               >
+                  <span class="row-icon">📁</span>
+                  <span class="row-name" @click="enterFolder(folder.id)">{{ folder.name }}</span>
+                  <span class="row-meta">{{ filesStore.files.filter((f) => f.folderId === folder.id).length }} files</span>
+                  <button class="delete-btn" @click="handleDeleteFolder(folder)">✕</button>
+               </div>
+
+               <div
+                  v-for="file in rootFiles"
+                  :key="file.id"
+                  class="list-row file-row"
+               >
+                  <span class="row-icon">🗒</span>
+                  <span class="row-name" @click="handleLoadFile(file)">{{ file.name }}</span>
+                  <span class="row-meta">{{ formatDate(file.savedAt) }}</span>
+                  <button class="delete-btn" @click="handleDeleteFile(file)">✕</button>
+               </div>
+            </template>
+
+            <template v-else>
+               <div
+                  v-for="file in visibleFiles"
+                  :key="file.id"
+                  class="list-row file-row"
+               >
+                  <span class="row-icon">🗒</span>
+                  <span class="row-name" @click="handleLoadFile(file)">{{ file.name }}</span>
+                  <span class="row-meta">{{ formatDate(file.savedAt) }}</span>
+                  <button class="delete-btn" @click="handleDeleteFile(file)">✕</button>
+               </div>
+            </template>
+         </div>
+      </div>
+   </VueFinalModal>
+</template>
+
+<style lang="scss">
+.files-modal-content {
+   height: auto !important;
+   max-height: 70% !important;
+   width: 600px !important;
+   max-width: calc(100% - 20px) !important;
+   padding-bottom: 1rem !important;
+
+   @media (max-width: $screen-sm) {
+      max-height: 80% !important;
+   }
+}
+</style>
+
+<style lang="scss" scoped>
+.files-modal {
+   display: flex;
+   flex-direction: column;
+   gap: 0.6rem;
+
+   h1 {
+      font-size: 1.375rem;
+      margin: 0;
+   }
+}
+
+.breadcrumb {
+   display: flex;
+   align-items: center;
+   gap: 0.4rem;
+   font-size: 0.85rem;
+   color: rgba(255, 255, 255, 0.55);
+
+   .breadcrumb-item {
+      cursor: pointer;
+
+      &.active {
+         color: white;
+         cursor: default;
+      }
+
+      &:not(.active):hover {
+         color: rgba(255, 255, 255, 0.85);
+      }
+   }
+
+   .breadcrumb-sep {
+      color: rgba(255, 255, 255, 0.35);
+   }
+}
+
+.files-actions {
+   display: flex;
+   gap: 0.5rem;
+
+   .action-btn {
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 0.4rem;
+      color: white;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      margin: 0;
+      transition: background 0.15s ease;
+
+      &:hover {
+         background: rgba(255, 255, 255, 0.13);
+         opacity: 1;
+      }
+   }
+}
+
+.inline-input-row {
+   display: flex;
+   gap: 0.5rem;
+   align-items: center;
+
+   input {
+      flex: 1;
+      background: rgba(0, 0, 0, 0.25);
+      border: none;
+      border-bottom: 4px solid rgba(255, 255, 255, 0.15);
+      border-radius: 3px 3px 0 0;
+      color: white;
+      padding: 0.3rem 0.5rem;
+      font-size: 0.9rem;
+      height: 34px;
+      font-family: inherit;
+
+      &:focus {
+         outline: none;
+         border-bottom-color: rgba(255, 255, 255, 0.4);
+      }
+   }
+
+   button {
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 0.4rem;
+      color: white;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      margin: 0;
+      transition: background 0.15s ease;
+
+      &:hover {
+         background: rgba(255, 255, 255, 0.13);
+         opacity: 1;
+      }
+   }
+}
+
+.files-list {
+   display: flex;
+   flex-direction: column;
+   gap: 0.35rem;
+   overflow-y: auto;
+   max-height: 400px;
+   padding-right: 2px;
+
+   &::-webkit-scrollbar {
+      width: 19px;
+   }
+
+   &::-webkit-scrollbar-track {
+      background: transparent;
+   }
+
+   &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.1);
+      border: 6px solid transparent;
+      border-radius: 10px;
+      background-clip: padding-box;
+   }
+}
+
+.empty-state {
+   color: rgba(255, 255, 255, 0.45);
+   font-size: 0.9rem;
+   padding: 1.5rem 0;
+   text-align: center;
+}
+
+.list-row {
+   display: flex;
+   align-items: center;
+   gap: 0.5rem;
+   padding: 0.45rem 0.6rem;
+   border-radius: 0.4rem;
+   background: rgba(255, 255, 255, 0.04);
+   border: 1px solid rgba(255, 255, 255, 0.07);
+   transition: background 0.12s ease;
+
+   &:hover {
+      background: rgba(255, 255, 255, 0.09);
+   }
+
+   .row-icon {
+      font-size: 1rem;
+      flex-shrink: 0;
+   }
+
+   .row-name {
+      flex: 1;
+      cursor: pointer;
+      font-size: 0.9rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      &:hover {
+         text-decoration: underline;
+      }
+   }
+
+   .row-meta {
+      font-size: 0.75rem;
+      color: rgba(255, 255, 255, 0.4);
+      white-space: nowrap;
+      flex-shrink: 0;
+   }
+
+   .delete-btn {
+      background: transparent;
+      border: none;
+      color: rgba(255, 255, 255, 0.3);
+      cursor: pointer;
+      font-size: 0.8rem;
+      padding: 0 0.2rem;
+      flex-shrink: 0;
+      margin: 0;
+      transition: color 0.12s ease;
+
+      &:hover {
+         color: #e06060;
+         opacity: 1;
+      }
+   }
+}
+
+.folder-row .row-name {
+   font-weight: 500;
+}
+</style>

--- a/src/components/Files/FilesModal.vue
+++ b/src/components/Files/FilesModal.vue
@@ -47,7 +47,7 @@ const toggleFolderInput = () => {
 const toggleFileInput = () => {
    showFileInput.value = !showFileInput.value;
    showFolderInput.value = false;
-   newFileName.value = '';
+   newFileName.value = showFileInput.value ? (cardStore.cards[0].name || '') : '';
 };
 
 const handleCreateFolder = async () => {

--- a/src/components/Files/FilesModal.vue
+++ b/src/components/Files/FilesModal.vue
@@ -7,7 +7,7 @@ import { useFilesStore } from '@/stores/files.store';
 import { buildCardParams } from '@/utils/serializeState';
 import { BaseHr } from '../common';
 
-defineEmits(['close']);
+const emit = defineEmits(['close']);
 
 const cardStore = useCardStore();
 const filesStore = useFilesStore();
@@ -69,12 +69,13 @@ const handleSaveFile = async () => {
 
 const handleNew = () => {
    cardStore.reset();
-   $toast.success('New card created');
+   emit('close');
 };
 
 const handleLoadFile = (file) => {
    cardStore.setFromParams(new URLSearchParams(file.params));
    $toast.success(`Loaded "${file.name}"`);
+   emit('close');
 };
 
 const handleDeleteFolder = async (folder) => {

--- a/src/components/Share/Share.vue
+++ b/src/components/Share/Share.vue
@@ -112,10 +112,22 @@ const handleDownload = async (fileType, close) => {
 
 <template>
    <div class="share">
-      <button @click="handleShare">Share</button>
+      <button title="Share" @click="handleShare">
+         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
+            <polyline points="16 6 12 2 8 6"/>
+            <line x1="12" y1="2" x2="12" y2="15"/>
+         </svg>
+      </button>
 
       <Popper arrow>
-         <button>Download</button>
+         <button title="Download">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+               <polyline points="7 10 12 15 17 10"/>
+               <line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+         </button>
          <template #content="{ close }">
             <div class="download-options">
                <button @click="handleDownload('svg', close)">
@@ -128,9 +140,19 @@ const handleDownload = async (fileType, close) => {
          </template>
       </Popper>
 
-      <button @click="openFiles">Files</button>
+      <button title="Files" @click="openFiles">
+         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+         </svg>
+      </button>
 
-      <button @click="openHelp">Help</button>
+      <button title="Help" @click="openHelp">
+         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+         </svg>
+      </button>
    </div>
 </template>
 
@@ -153,9 +175,17 @@ const handleDownload = async (fileType, close) => {
       border: none;
       border-radius: 3px;
       color: white;
+      padding: 5px 7px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: all 0.15s ease;
       &:hover {
          opacity: 0.6;
+      }
+
+      svg {
+         display: block;
       }
    }
 

--- a/src/components/Share/Share.vue
+++ b/src/components/Share/Share.vue
@@ -114,8 +114,9 @@ const handleDownload = async (fileType, close) => {
    <div class="share">
       <button title="Share" @click="handleShare">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M3 17a9 9 0 0 1 9-9h7"/>
-            <polyline points="15 4 19 8 15 12"/>
+            <path d="M14 4H5a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9"/>
+            <path d="M8 16c1-5 5-8 12-8"/>
+            <polyline points="16 3 20 7 16 11"/>
          </svg>
       </button>
 

--- a/src/components/Share/Share.vue
+++ b/src/components/Share/Share.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { useModal } from 'vue-final-modal';
 import * as htmlToImage from 'html-to-image';
-import map from 'lodash/map';
 import Popper from 'vue3-popper';
 import { useToast } from 'vue-toast-notification';
 import { useCardStore } from '@/stores/card.store';
 import * as CardTypes from '@/constants/cardTypes.constants';
+import { buildCardParams } from '@/utils/serializeState';
 import ShareHelpModal from './ShareHelpModal.vue';
+import FilesModal from '@/components/Files/FilesModal.vue';
 
 const $toast = useToast();
 const cardStore = useCardStore();
@@ -16,31 +17,13 @@ const { open: openHelp, close: closeHelp } = useModal({
    attrs: { onClose: () => closeHelp() },
 });
 
+const { open: openFiles, close: closeFiles } = useModal({
+   component: FilesModal,
+   attrs: { onClose: () => closeFiles() },
+});
+
 const handleShare = () => {
-   const { cardType, syndicate, rarity, cards } = cardStore;
-   const params = { cardType, syndicate, rarity };
-
-   cards.forEach((card) => {
-      Object.keys(card).forEach((key) => {
-         if (key === 'rarity') return;
-
-         let value =
-            typeof card[key] === 'object'
-               ? map(card[key], (v, k) => `${k}:${v}`).join(',')
-               : card[key];
-         value = encodeURIComponent(value);
-
-         if (params[key]) {
-            params[key] += `;${value}`;
-         } else {
-            params[key] = value;
-         }
-      });
-   });
-
-   const search = new URLSearchParams(params);
-   navigator.clipboard.writeText(window.location.href + '?' + search);
-
+   navigator.clipboard.writeText(window.location.href + '?' + buildCardParams(cardStore));
    $toast.success('Link copied to clipboard!');
 };
 
@@ -145,6 +128,8 @@ const handleDownload = async (fileType, close) => {
          </template>
       </Popper>
 
+      <button @click="openFiles">Files</button>
+
       <button @click="openHelp">Help</button>
    </div>
 </template>
@@ -183,7 +168,7 @@ const handleDownload = async (fileType, close) => {
    @media (max-width: $screen-sm) {
       width: calc(100% - 20px);
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(4, 1fr);
 
       button {
          width: 100%;

--- a/src/components/Share/Share.vue
+++ b/src/components/Share/Share.vue
@@ -114,9 +114,8 @@ const handleDownload = async (fileType, close) => {
    <div class="share">
       <button title="Share" @click="handleShare">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
-            <polyline points="16 6 12 2 8 6"/>
-            <line x1="12" y1="2" x2="12" y2="15"/>
+            <path d="M3 17a9 9 0 0 1 9-9h7"/>
+            <polyline points="15 4 19 8 15 12"/>
          </svg>
       </button>
 

--- a/src/components/Share/Share.vue
+++ b/src/components/Share/Share.vue
@@ -114,9 +114,9 @@ const handleDownload = async (fileType, close) => {
    <div class="share">
       <button title="Share" @click="handleShare">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M14 4H5a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9"/>
-            <path d="M8 16c1-5 5-8 12-8"/>
-            <polyline points="16 3 20 7 16 11"/>
+            <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
+            <polyline points="16 6 12 2 8 6"/>
+            <line x1="12" y1="2" x2="12" y2="15"/>
          </svg>
       </button>
 

--- a/src/stores/card.store.js
+++ b/src/stores/card.store.js
@@ -46,6 +46,13 @@ export const useCardStore = defineStore('card', {
          this.cards[index].artPos[name] = Number(value);
       },
 
+      reset() {
+         this.cardType = CardTypes.AGENT;
+         this.syndicate = '';
+         this.rarity = Rarities.COMMON;
+         this.cards = [cloneDeep(agentState), cloneDeep(agentState)];
+      },
+
       setFromParams(params) {
          if (!params.size) return;
 

--- a/src/stores/files.store.js
+++ b/src/stores/files.store.js
@@ -1,0 +1,63 @@
+import { defineStore } from 'pinia';
+import { openDB } from 'idb';
+
+const DB_NAME = 'custom-chrono';
+const DB_VERSION = 1;
+
+let _db = null;
+
+async function getDb() {
+   if (_db) return _db;
+   _db = await openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+         if (!db.objectStoreNames.contains('folders')) {
+            db.createObjectStore('folders', { keyPath: 'id' });
+         }
+         if (!db.objectStoreNames.contains('files')) {
+            const store = db.createObjectStore('files', { keyPath: 'id' });
+            store.createIndex('folderId', 'folderId');
+         }
+      },
+   });
+   return _db;
+}
+
+export const useFilesStore = defineStore('files', {
+   state: () => ({ folders: [], files: [], loaded: false }),
+   actions: {
+      async load() {
+         if (this.loaded) return;
+         const db = await getDb();
+         this.folders = await db.getAll('folders');
+         this.files = await db.getAll('files');
+         this.loaded = true;
+      },
+      async createFolder(name) {
+         const folder = { id: crypto.randomUUID(), name };
+         const db = await getDb();
+         await db.put('folders', folder);
+         this.folders.push(folder);
+      },
+      async deleteFolder(id) {
+         const db = await getDb();
+         const tx = db.transaction(['folders', 'files'], 'readwrite');
+         await tx.objectStore('folders').delete(id);
+         const toDelete = await tx.objectStore('files').index('folderId').getAllKeys(id);
+         await Promise.all(toDelete.map((k) => tx.objectStore('files').delete(k)));
+         await tx.done;
+         this.folders = this.folders.filter((f) => f.id !== id);
+         this.files = this.files.filter((f) => f.folderId !== id);
+      },
+      async saveFile(name, params, folderId = null) {
+         const file = { id: crypto.randomUUID(), name, folderId, params, savedAt: Date.now() };
+         const db = await getDb();
+         await db.put('files', file);
+         this.files.push(file);
+      },
+      async deleteFile(id) {
+         const db = await getDb();
+         await db.delete('files', id);
+         this.files = this.files.filter((f) => f.id !== id);
+      },
+   },
+});

--- a/src/utils/serializeState.js
+++ b/src/utils/serializeState.js
@@ -1,0 +1,26 @@
+import map from 'lodash/map';
+
+export function buildCardParams(cardStore) {
+   const { cardType, syndicate, rarity, cards } = cardStore;
+   const params = { cardType, syndicate, rarity };
+
+   cards.forEach((card) => {
+      Object.keys(card).forEach((key) => {
+         if (key === 'rarity') return;
+
+         let value =
+            typeof card[key] === 'object'
+               ? map(card[key], (v, k) => `${k}:${v}`).join(',')
+               : card[key];
+         value = encodeURIComponent(value);
+
+         if (params[key]) {
+            params[key] += `;${value}`;
+         } else {
+            params[key] = value;
+         }
+      });
+   });
+
+   return new URLSearchParams(params).toString();
+}


### PR DESCRIPTION
Users can now save, organise, and reload card designs through a new
Files modal. Files are serialised as URL params (same method as Share)
and persisted in IndexedDB via the idb library. The card-state
serialisation logic has been extracted into a shared utility so Share
and Files use identical output.

https://claude.ai/code/session_01LMwMAGkKV4DLArxtmpe28F